### PR TITLE
fix: display ascii code in assembly language.

### DIFF
--- a/four/assembly/related/ascii.asm
+++ b/four/assembly/related/ascii.asm
@@ -1,0 +1,22 @@
+# Display ASCII Code
+
+.model small
+.stack 100h
+.code
+main proc
+   mov cx,255
+   mov bx,0
+   
+   level:
+   mov ah,02
+   mov dl,bl
+   int 21h
+   inc bl
+
+   loop level
+
+   exit:
+   mov ah,4ch
+   int 21h
+   main endp
+end main


### PR DESCRIPTION
1.write code for display all ascii code using loop level end point 255 which is last number of ascii code.